### PR TITLE
Improve inventory

### DIFF
--- a/Background.cpp
+++ b/Background.cpp
@@ -4,6 +4,7 @@
 
 #include "Background.h"
 #include <iostream>
+#include <cmath>
 Background::Background(std::string file, float dist, sf::Vector2f s){
     file_path=file;
     distance = dist;
@@ -33,9 +34,9 @@ void Background::Draw(sf::RenderWindow & renderWindow)
     float x_view1 = centerView.x-sizeView.x/2;
     float x_view2 = centerView.x+sizeView.x/2;
     float dist = x_view1-position.x;
-    float first_x = (floor(dist/size.x))*size.x+position.x;
+    float first_x = (std::floor(dist/size.x))*size.x+position.x;
     for(int i = first_x; i<x_view2; i= i+size.x){
-        s.setPosition(sf::Vector2f(i, position.y-600*pow(distance,-1)));
+        s.setPosition(sf::Vector2f(i, position.y-600*std::pow(distance,-1)));
         renderWindow.draw(s);
     }
     //std::cout << distance << " " << x_view1 << " "<< first_x << " " << size.x << " "<<  ceilf(distance/size.x)<< std::endl;

--- a/Game.cpp
+++ b/Game.cpp
@@ -148,8 +148,12 @@ void Game::GameLoop(double delta)
             Game::map_curr.DrawFrontItems(window);
             Game::player.DrawInventory(window);
             while(window.pollEvent(currentEvent))
-            {
-                if (currentEvent.type == sf::Event::Closed ||
+	    {
+                if(currentEvent.type == sf::Event::MouseWheelScrolled)
+		{
+                    Game::inputs.UpdateWheel(currentEvent.mouseWheelScroll.delta);
+                }
+		else if (currentEvent.type == sf::Event::Closed ||
                     ((currentEvent.type == sf::Event::KeyPressed) &&
                      (currentEvent.key.code == sf::Keyboard::Escape)))
                 {
@@ -158,10 +162,7 @@ void Game::GameLoop(double delta)
                     //window.close();
                 }
             }
-
-
             break;
-
         }
     }
 }

--- a/Inputs.cpp
+++ b/Inputs.cpp
@@ -26,6 +26,8 @@ Inputs::Inputs()
 	keys["A"] = sf::Vector2i(0,0);
 	keys["D"] = sf::Vector2i(0,0);
 	keys["Space"] = sf::Vector2i(0,0);
+	keys["wheel"] = sf::Vector2i(0,0);
+	wheelDelta = 0;
 }
 
 
@@ -56,7 +58,14 @@ void Inputs::Update(){
 	UpdateKey(sf::Keyboard::isKeyPressed(sf::Keyboard::A), "A");
 	UpdateKey(sf::Keyboard::isKeyPressed(sf::Keyboard::D), "D");
 	UpdateKey(sf::Keyboard::isKeyPressed(sf::Keyboard::Space), "Space");
+	keys["wheel"] = sf::Vector2i(wheelDelta, 0);
+	wheelDelta = 0;
 }
+
+void Inputs::UpdateWheel(int delta) {
+	wheelDelta = delta;
+}
+
 sf::Vector2i Inputs::getKey(std::string s){
 	return keys[s];
 }

--- a/Inputs.h
+++ b/Inputs.h
@@ -7,6 +7,7 @@ public:
 	virtual ~Inputs();
 
 	virtual void Update();
+	void UpdateWheel(int delta);
 	sf::Vector2i getKey(std::string s);
 
 protected:
@@ -16,4 +17,5 @@ protected:
 private:
 	void UpdateKey(bool pressed, std::string key);
 	std::map<std::string, sf::Vector2i> keys;
+	int wheelDelta;
 };

--- a/Inventory.cpp
+++ b/Inventory.cpp
@@ -722,4 +722,11 @@ void Inventory::Update(Inputs &inputs, sf::RenderWindow &window)
 			show_craft_list = true;
 		}
 	}
+
+	int tab_selection_delta = inputs.getKey("wheel").x;
+	tab_item_selected = (tab_item_selected - tab_selection_delta);
+	while (tab_item_selected < 0) {
+		tab_item_selected += TAB_SLOTS;
+	}
+	tab_item_selected %= TAB_SLOTS;
 }

--- a/Inventory.cpp
+++ b/Inventory.cpp
@@ -54,6 +54,8 @@ Inventory::Inventory()
 	craft_list [0] = craft1;
 	craft_list [1] = craft2;
 
+	tab_item_selected = 0;
+
 }
 
 Inventory::~Inventory()
@@ -246,12 +248,13 @@ int Inventory::giveItemInventory(std::string id_item, int amount){
 int Inventory::stackItem(std::string id, int amount){
 	int residue = amount;
 
-	if(existItemTabNoFull(id)) residue = stackItemTab(id, amount);
+	if(existItemTabNoFull(id)) residue = stackItemTab(id, residue);
 	if(residue == 0) return 0;
-	else residue = stackItemInventory(id, amount);
+	if(existItemInventoryNoFull(id)) residue = stackItemInventory(id, residue);
 	if(residue == 0) return 0;
-	else residue = giveItemTab(id, amount);
-	return residue;
+	if(!isTabFull()) residue = giveItemTab(id, residue);
+	if(residue == 0) return 0;
+	return giveItemInventory(id, residue);
 	/*
 	if(!giveItemTab(id, amount)){
 		if(!giveItemInventory(id, amount)) return false;
@@ -609,8 +612,8 @@ void Inventory::Draw(sf::RenderWindow& renderWindow)
 		for(int i = 0; i<TAB_SLOTS; i = ++i){
 			rectangle.setPosition(sf::Vector2f(i*SLOT_SIZE+x_tab, y_tab));
 			renderWindow.draw(rectangle);
-			
 		}
+
 		for(int i = 0; i<TAB_SLOTS; ++i){
 
 			Item* item = tab[i];
@@ -626,6 +629,12 @@ void Inventory::Draw(sf::RenderWindow& renderWindow)
 
 			}
 		}
+		sf::RectangleShape selected(rectangle);
+		selected.setPosition(sf::Vector2f(tab_item_selected*SLOT_SIZE+x_tab, y_tab));
+		selected.setFillColor(sf::Color::Transparent);
+		selected.setOutlineThickness(GRID_SELECTED_THICKNESS);
+		selected.setOutlineColor(sf::Color(210, 160, 70));
+		renderWindow.draw(selected);
 	}
 	if(show_craft_list){
 		

--- a/Inventory.h
+++ b/Inventory.h
@@ -12,6 +12,7 @@ public:
 	const static int TAB_SLOTS = 8;
 	const static int SLOT_SIZE = 50;
 	const static int GRID_THICKNESS = 2;
+	const static int GRID_SELECTED_THICKNESS = 4;
 	const static int N_CRAFT_ITEMS = 2;
 
 	
@@ -61,6 +62,7 @@ private:
 	float x_craft_list;
 	float y_craft_list;
 
+	int tab_item_selected;
 
 	Item* craft_list[N_CRAFT_ITEMS];
 	Item* inventory[Y_SLOTS][X_SLOTS] = { {nullptr} };
@@ -68,5 +70,4 @@ private:
 	Item* mouseItem = nullptr;
 
 	TextureManager* texMan;
-
 };


### PR DESCRIPTION
Items are now collected similar to Minecraft and Terraria, going first to the Tab if there is a non-full stack there, going to inventory if there is a non-full stack there, otherwise adding new item to Tab, or Inventory if Tab is full.

Mouse wheel keys are saved as well. They are done in a different way from other keys, as they can only be obtained in the pollEvent loop.

There is a 'selected tab item', which is highlighted and can be changed with the mouse wheel.

This makes it easy to implement the feature to insert blocks (I will send a future pull request for this).
