### PR TITLE
Add cooldown to remove a tile and the posibility to put your items to tiles

### DIFF
--- a/Inventory.cpp
+++ b/Inventory.cpp
@@ -172,8 +172,17 @@ int Inventory::decrementItem(std::string id_item, int amount){
 					}
 				}
 			}
-			
+
 		}
+	}
+}
+void Inventory::decrementItemAtTab() {
+	Item* item = tab[tab_item_selected];
+	if (item == nullptr) return;
+	item->amount -= 1;
+	if (item->amount <= 0) {
+		delete item;
+		tab[tab_item_selected] = nullptr;
 	}
 }
 int Inventory::stackItemInventory(std::string id_item, int amount){
@@ -364,13 +373,16 @@ void Inventory::craftItem(std::string id_item){
 			}
 			int res = stackItem(id_item,1);
 		}
-		
+
 	}
-	
+
 
 }
 std::string Inventory::getIdCraftItem(int index){
 	return craft_list[index]->id;
+}
+std::string Inventory::getIdItemAtTab() {
+	return tab[tab_item_selected] != nullptr ? tab[tab_item_selected]->id : "0";
 }
 void Inventory::inventoryClick(float x, float y, std::string key){
 	int index_tab = getTabIndex(sf::Vector2f(x,y));

--- a/Inventory.h
+++ b/Inventory.h
@@ -15,12 +15,14 @@ public:
 	const static int GRID_SELECTED_THICKNESS = 4;
 	const static int N_CRAFT_ITEMS = 2;
 
-	
-	
-	
+
+
+
 	void Draw(sf::RenderWindow& renderWindow);
 	void Update(Inputs &inputs, sf::RenderWindow &window);
 	int stackItem(std::string id, int amount);
+	std::string getIdItemAtTab();
+	void decrementItemAtTab();
 	bool show_inventory;
 	bool show_tab;
 	bool show_craft_list;

--- a/Player.cpp
+++ b/Player.cpp
@@ -408,42 +408,55 @@ void Player::Update(float delta, Map &map, Inputs &inputs, sf::RenderWindow &win
 	    Tile* t = map.getTile(position.x, position.y, 1);
 		//std::cout << t->id_temp << " " <<true_position.x << " " << true_position.y << std::endl;
 	    int position_tile = 1;
-	    if(t->id =="0"){
+	    if(t->id == "0"){
 	    	position_tile = 0;
 	    	t = map.getTile(position.x, position.y, 0);
 	    }
+			if (t != tile_being_removed && tile_being_removed != nullptr) {
+				tile_being_removed->being_removed = false;
+			}
 	    sf::Vector2f playerPos((GetPosition().x+GetWidth())/2,(GetPosition().y+GetHeight())/2);
 	    sf::Vector2f tilePos((t->GetPosition().x+t->GetWidth())/2,(t->GetPosition().y+t->GetHeight())/2);
 	    float dist = sqrt((playerPos.x-tilePos.x)*(playerPos.x-tilePos.x) + (playerPos.y-tilePos.y)*(playerPos.y-tilePos.y));
-   
-	    if(position_tile == 1 && t->id != "0") {
 
-	    	if(giveItem(t->id, 1)){
-
-	    		map.removeTile2(t);
-	    	}
+	    if(t->id != "0") {
+				tile_being_removed = t;
+				if (tile_being_removed->being_removed) {
+					tile_being_removed->ms_to_be_removed -= delta*1000;
+					if (tile_being_removed->ms_to_be_removed < 0) {
+						if(giveItem(t->id, 1)){
+							map.removeTile2(t);
+						}
+					}
+				}
+				else {
+					tile_being_removed->being_removed = true;
+					tile_being_removed->ms_to_be_removed = tile_being_removed->ms_to_remove;
+				}
 	    }
 
 	}
 	else if (mouseRight.x == 1 && !inventory->show_inventory)
 	{
 
-	    Tile* t = map.getTile(position.x, position.y, 1);
-	    int position_tile = 1;
-	    if(t->id =="0"){
-	    	position_tile = 0;
-	    	t = map.getTile(position.x, position.y, 0);
+	    Tile* t = map.getTile(position.x, position.y, 0);
+	    int position_tile = 0;
+	    if(t->id != "0") {
+	    	position_tile = 1;
+	    	t = map.getTile(position.x, position.y, 1);
 	    }
 	    sf::Vector2f playerPos((GetPosition().x+GetWidth())/2,(GetPosition().y+GetHeight())/2);
 	    sf::Vector2f tilePos((t->GetPosition().x+t->GetWidth())/2,(t->GetPosition().y+t->GetHeight())/2);
 	    float dist = sqrt((playerPos.x-tilePos.x)*(playerPos.x-tilePos.x) + (playerPos.y-tilePos.y)*(playerPos.y-tilePos.y));
-   
-	    if(position_tile == 0 && t->id != "0") {
 
-	    	if(giveItem(t->id, 1)){
-	    		//t->Remove();
-	    		map.removeTile2(t);
-	    	}
+	    if(t->id == "0") {
+				std::string idOfTabItem = inventory->getIdItemAtTab();
+				if ((position_tile == 0 && std::islower(idOfTabItem[0])) ||
+				    (position_tile == 1 && std::isupper(idOfTabItem[0]))
+				) {
+					t->Reload(inventory->getIdItemAtTab());
+					inventory->decrementItemAtTab();
+				}
 	    }
 
 	}

--- a/Player.h
+++ b/Player.h
@@ -41,10 +41,11 @@ private:
 	//INVENTORY
 	Inventory* inventory;
 
+	//REMOVE AND PUT TILES;
+	Tile* tile_being_removed;
 
 	//SHOW
 	sf::Sprite _sprite;
 	sf::Texture _image;
 	std::string _filename;
 };
-

--- a/Tile.cpp
+++ b/Tile.cpp
@@ -17,6 +17,7 @@
 Tile::Tile(int id_t, int l){
     id_temp = id_t;
     layer = l;
+    being_removed = false;
 }
 
 
@@ -35,6 +36,7 @@ void Tile::Reload(std::string new_id)
 		max_tension = 0;
 		rigid = false;
 		reach_floor = false;
+    ms_to_remove = 1e9;
 	}
 	else if(new_id == "D"){
         reach_sun = false;
@@ -42,6 +44,7 @@ void Tile::Reload(std::string new_id)
 		max_tension = 100;
 		rigid = false;
 		reach_floor = true;
+    ms_to_remove = 100;
 	}
 	else if(new_id == "d"){
         reach_sun = false;
@@ -49,6 +52,7 @@ void Tile::Reload(std::string new_id)
 		max_tension = 100;
 		rigid = false;
 		reach_floor = false;
+    ms_to_remove = 100;
 	}
 	else if(new_id == "r"){
         reach_sun = false;
@@ -56,6 +60,7 @@ void Tile::Reload(std::string new_id)
 		max_tension = 200;
 		rigid = false;
 		reach_floor = false;
+    ms_to_remove = 100;
 	}
     else if(new_id == "C"){
         reach_sun = false;
@@ -63,6 +68,7 @@ void Tile::Reload(std::string new_id)
         max_tension = 500;
         rigid = false;
         reach_floor = false;
+        ms_to_remove = 100;
     }
     else if(new_id == "c"){
         reach_sun = false;
@@ -70,6 +76,7 @@ void Tile::Reload(std::string new_id)
         max_tension = 500;
         rigid = false;
         reach_floor = false;
+        ms_to_remove = 100;
     }
 	else{
 		Reload("0");

--- a/Tile.h
+++ b/Tile.h
@@ -25,6 +25,9 @@ public:
 	int layer;
 	int max_tension;
 	int weight;
+	float ms_to_remove;
+	float ms_to_be_removed;
+	bool being_removed;
 	std::string id; //sha de privatitzar
     int id_temp;
 	Tile* neighbors[9] = {nullptr};


### PR DESCRIPTION
That was hard :rocket: 

I don't know if the cooldown thing is something intended in the game. I made it because without cooldown, when removing items with the same button, you removed the front and the back tile instantly.

And when you put a tile, only is removed the item that you have in your tab. Maybe is preferred to empty the inventory first... dunno :dancer: 
